### PR TITLE
Add Firestore-backed leaderboard for Snake

### DIFF
--- a/snake.html
+++ b/snake.html
@@ -23,6 +23,6 @@
         <button id="replayButton" style="display: none;">Rejouer</button>
         <div id="leaderboard"></div>
     </div>
-    <script src="snake.js"></script>
+    <script type="module" src="snake.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- connect Snake game to Firebase Firestore
- load and display global top 10 scores
- save player's score to Firestore
- switch snake script to module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846a98b225c8327aaf510f87f878a5d